### PR TITLE
Changed for name update to Matomo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:5.6-apache
 MAINTAINER Benjamin Hutchins <ben@hutchins.co>
 
-ENV PIWIK_VERSION 3.2.0
+ENV MATOMO_VERSION 3.3.0
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -60,13 +60,13 @@ RUN apt-get update \
   && apt-get install -y cron \
   && rm -rf /var/lib/apt/lists/*
 
-# Piwik
-RUN wget http://builds.piwik.org/piwik-${PIWIK_VERSION}.tar.gz \
-    && tar --strip 1 -xzf piwik-${PIWIK_VERSION}.tar.gz \
-    && rm piwik-${PIWIK_VERSION}.tar.gz \
+# Matomo
+RUN wget http://builds.matomo.org/piwik-${MATOMO_VERSION}.tar.gz \
+    && tar --strip 1 -xzf piwik-${MATOMO_VERSION}.tar.gz \
+    && rm piwik-${MATOMO_VERSION}.tar.gz \
     && chown -R www-data:www-data tmp config
 
-# Piwik config directory
+# Matomo config directory
 RUN cp -r /var/www/html/config /var/www/html/config.original/
 
 VOLUME /var/www/html/config/

--- a/README.md
+++ b/README.md
@@ -1,31 +1,31 @@
-# What is Piwik?
+# What is Matomo?
 
-Piwik is an open-source web analytics platform, providing detailed reports of web traffic.
+Matomo is an open-source web analytics platform, providing detailed reports of web traffic.
 
-> [http://piwik.org/](http://piwik.org/)
+> [http://mattomo.org/](http://matomo.org/)
 
 # Usage
 
     docker run \
-      --name piwik \
+      --name matamo \
       --link some-mysql:mysql \
       -p 80:80 \
       -v $(pwd)/config:/var/www/html/config/:rw \
-      benhutchins/piwik
+      benhutchins/matomo
 
 ## Database
 
-The example above uses `--link` to connect the Piwik container with a running [mysql](https://hub.docker.com/_/mysql/) container. To start a mysql container simply run:
+The example above uses `--link` to connect the Matomo container with a running [mysql](https://hub.docker.com/_/mysql/) container. To start a mysql container simply run:
 
     docker run \
       --name some-mysql \
       -e MYSQL_ROOT_PASSWORD=password \
-      -e MYSQL_DATABASE=piwik \
-      -e MYSQL_USER=piwik \
+      -e MYSQL_DATABASE=matomo \
+      -e MYSQL_USER=matomo \
       -e MYSQL_PASSWORD=password \
       mysql
 
-You'll want to configure the database name, user and password whcih will be used as part of the Piwik installation process.
+You'll want to configure the database name, user and password whcih will be used as part of the Matomo installation process.
 
 ## Docker Compose
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Matomo is an open-source web analytics platform, providing detailed reports of web traffic.
 
-> [http://mattomo.org/](http://matomo.org/)
+> [http://matomo.org/](http://matomo.org/)
 
 # Usage
 


### PR DESCRIPTION
Changed names everywhere, due note that they have not changed the download zip file (still called piwik) also assuming you would update this to docker hub with the name matomo instead of piwik (as stated in the readme)